### PR TITLE
Fix wrong check for test.fits file

### DIFF
--- a/process.py
+++ b/process.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         fnames = sorted(glob.glob("2*.fits"))
 
         # Create reference calibration file
-        if not os.path.exists("test.fits"):
+        if os.path.exists("test.fits"):
             solved = False
             # Loop over files to find a suitable calibration file
             for fname in fnames:


### PR DESCRIPTION
The condition becomes true when the file test.fits
does not exist.

Signed-off-by: Agis Zisimatos <agzisim@gmail.com>