### PR TITLE
Unify CLI argument -c / --conf_file behaviour

### DIFF
--- a/acquire.py
+++ b/acquire.py
@@ -11,6 +11,7 @@ from astropy.time import Time
 from astropy.io import fits
 import astropy.units as u
 from stvid.utils import get_sunset_and_sunrise
+from stvid.config import add_argument_conf_file, load_config
 import logging
 import configparser
 import argparse
@@ -546,12 +547,7 @@ if __name__ == '__main__':
     # Read commandline options
     conf_parser = argparse.ArgumentParser(description="Capture and compress" +
                                                       " live video frames.")
-    conf_parser.add_argument("-c", "--conf_file",
-                             help="Specify configuration file(s). If no file" +
-                             " is specified 'configuration.ini' is used.",
-                             action="append",
-                             nargs="?",
-                             metavar="FILE")
+    conf_parser = add_argument_conf_file(conf_parser)
     conf_parser.add_argument("-t", "--test", 
                              nargs="?",
                              action="store", 
@@ -563,15 +559,8 @@ if __name__ == '__main__':
 
     args = conf_parser.parse_args()
 
-    # Process commandline options and parse configuration
-    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
-    
-    conf_file = args.conf_file if args.conf_file else "configuration.ini"
-    result = cfg.read(conf_file)
-
-    if not result:
-        print("Could not read config file: %s\nExiting..." % conf_file)
-        sys.exit()
+    # Parse configuration
+    cfg = load_config(args.conf_files)
 
     # Setup logging
     logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] " +
@@ -596,7 +585,7 @@ if __name__ == '__main__':
     logger.addHandler(consoleHandler)
     logger.setLevel(logging.DEBUG)
 
-    logger.info("Using config: %s" % conf_file)
+    # Process commandline options
 
     # Testing mode
     if args.test is None:

--- a/imgstat.py
+++ b/imgstat.py
@@ -6,18 +6,16 @@ import matplotlib.dates as mdates
 import astropy.units as u
 from astropy.coordinates import SkyCoord, AltAz, EarthLocation
 from astropy.time import Time
-import configparser
 import argparse
 import os
+
+from stvid.config import add_argument_conf_file, load_config
+
 
 if __name__ == "__main__":
     # Read commandline options
     conf_parser = argparse.ArgumentParser(description='Plot image statistics')
-    conf_parser.add_argument("-c",
-                             "--conf_file",
-                             help="Specify configuration file. If no file" +
-                             " is specified 'configuration.ini' is used.",
-                             metavar="FILE")
+    conf_parser = add_argument_conf_file(conf_parser)
     conf_parser.add_argument("-i",
                              "--input",
                              help="Specify file to be processed. If no file" +
@@ -39,13 +37,7 @@ if __name__ == "__main__":
         default="./imgstat.png")
 
     args = conf_parser.parse_args()
-
-    # Process commandline options and parse configuration
-    cfg = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
-    if args.conf_file:
-        cfg.read([args.conf_file])
-    else:
-        cfg.read('configuration.ini')
+    cfg = load_config(args.conf_files)
 
     # Move to processing directory
     os.chdir(args.file_dir)

--- a/keogram.py
+++ b/keogram.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import glob
 import numpy as np
 from stvid.stio import fourframe
-import configparser
+from stvid.config import add_argument_conf_file, load_config
 import argparse
 import os
 import matplotlib.pyplot as plt
@@ -43,11 +43,7 @@ if __name__ == "__main__":
     # Read commandline options
     conf_parser = argparse.ArgumentParser(description='Process captured' +
                                           ' video frames.')
-    conf_parser.add_argument("-c",
-                             "--conf_file",
-                             help="Specify configuration file. If no file" +
-                             " is specified 'configuration.ini' is used.",
-                             metavar="FILE")
+    conf_parser = add_argument_conf_file(conf_parser)
     conf_parser.add_argument("-d",
                              "--directory",
                              help="Specify directory of observations. If no" +
@@ -57,13 +53,7 @@ if __name__ == "__main__":
                              default=".")
 
     args = conf_parser.parse_args()
-
-    # Process commandline options and parse configuration
-    cfg = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
-    if args.conf_file:
-        cfg.read([args.conf_file])
-    else:
-        cfg.read('configuration.ini')
+    cfg = load_config(args.conf_files)
 
     # Generate keogram is it does not exist
     if not os.path.exists(os.path.join(args.file_dir, "keogram.npy")):

--- a/process.py
+++ b/process.py
@@ -21,6 +21,7 @@ from stvid import calibration
 from stvid.fourframe import FourFrame
 from stvid.fourframe import Observation
 from stvid.fourframe import AstrometricCatalog
+from stvid.config import add_argument_conf_file, load_config
 
 from astropy.utils.exceptions import AstropyWarning
 
@@ -210,13 +211,7 @@ if __name__ == "__main__":
     # Read commandline options
     conf_parser = argparse.ArgumentParser(description="Process captured" +
                                           " video frames.")
-    conf_parser.add_argument("-c",
-                             "--conf_file",
-                             help="Specify configuration file. If no file" +
-                             " is specified 'configuration.ini' is used.",
-                             action="append",
-                             nargs="?",
-                             metavar="FILE")
+    conf_parser = add_argument_conf_file(conf_parser)
     conf_parser.add_argument("-d",
                              "--directory",
                              help="Specify directory of observations. If no" +
@@ -241,14 +236,8 @@ if __name__ == "__main__":
                              help="Delay before processing new files (seconds, default: 10).",
                              type=int, default=10)
     args = conf_parser.parse_args()
-    
-    # Read configuration file
-    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ":"))
-    conf_file = args.conf_file if args.conf_file else "configuration.ini"
-    result = cfg.read(conf_file)
-    if not result:
-        print("Could not read config file: %s\nExiting..." % conf_file)
-        sys.exit()
+
+    cfg = load_config(args.conf_files)
 
     # Set warnings
     warnings.filterwarnings("ignore", category=UserWarning, append=True)

--- a/stvid/config.py
+++ b/stvid/config.py
@@ -1,0 +1,30 @@
+import sys
+import configparser
+
+
+def load_config(conf_files):
+    """
+    Load STVID configuration from one or more files.
+
+    Arguments
+    conf_files (list[str]): List of configuration files
+    """
+    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    result = cfg.read(conf_files)
+
+    if not result:
+        print(f"Could not read config files: {conf_files}\nExiting...")
+        sys.exit(1)
+    return cfg
+
+
+def add_argument_conf_file(parser):
+    parser.add_argument("-c", "--conf_file",
+                            help="Specify configuration file(s). If no file" +
+                            " is specified 'configuration.ini' is used.",
+                            action="append",
+                            nargs="?",
+                            metavar="FILE",
+                            dest="conf_files",
+                            default=["configuration.ini"])
+    return parser

--- a/update_tle.py
+++ b/update_tle.py
@@ -3,7 +3,6 @@ import re
 import os
 import datetime
 import argparse
-import configparser
 
 from io import BytesIO
 from shutil import copyfile
@@ -11,24 +10,16 @@ from zipfile import ZipFile
 from urllib.request import urlopen
 
 from spacetrack import SpaceTrackClient
+from stvid.config import add_argument_conf_file, load_config
+
 
 if __name__ == '__main__':
-    # Read commandline options
     conf_parser = argparse.ArgumentParser(description="Update TLEs from" +
                                                       " online sources")
-    conf_parser.add_argument("-c", "--conf_file",
-                             help="Specify configuration file. If no file" +
-                             " is specified 'configuration.ini' is used.",
-                             metavar="FILE")
-
+    conf_parser = add_argument_conf_file(conf_parser)
     args = conf_parser.parse_args()
 
-    # Process commandline options and parse configuration
-    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
-    if args.conf_file:
-        cfg.read([args.conf_file])
-    else:
-        cfg.read("configuration.ini")
+    cfg = load_config(args.conf_files)
 
     # Create TLE locatio
     tle_path = cfg.get("Elements", "tlepath")


### PR DESCRIPTION
This patch makes sure that all CLI tools behave the same regarding configuration file loading.
It adds support to load from multiple configuration files to all tools, following the existing interface of `acquire.py` and `process.py`.